### PR TITLE
deb: remove lteOnCdmaDevice from system.prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -4,7 +4,6 @@ rild.libpath=/system/lib/libril-qc-qmi-1.so
 ro.telephony.default_network=9
 ro.telephony.get_imsi_from_sim=true
 telephony.lteOnGsmDevice=1
-telephony.lteOnCdmaDevice=1
 DEVICE_PROVISIONED=1
 # Do not power down SIM card when modem is sent to Low Power Mode.
 persist.radio.apm_sim_not_pwdn=1


### PR DESCRIPTION
Remove telephony.lteOnCdmaDevice=1 from system.prop
Even if this is from stock it is unnessary/incorrect.

See https://review.lineageos.org/#/c/64932/ for full details.

Change-Id: Ibbd55f57d02656ce990efedf0227175659ac94d8